### PR TITLE
fix source_url for updates

### DIFF
--- a/blueprints/zigbee2mqtt_tuya_4_button_scene_switch_ts0044.yaml
+++ b/blueprints/zigbee2mqtt_tuya_4_button_scene_switch_ts0044.yaml
@@ -108,7 +108,7 @@ blueprint:
       default: []
       selector:
         action: {}
-  source_url: https://raw.githubusercontent.com/lux4rd0/homeassistant/main/blueprints/zigbee2mqtt_tuya_4_button_scene_switch_ts004f.yaml
+  source_url: https://raw.githubusercontent.com/lux4rd0/homeassistant/main/blueprints/zigbee2mqtt_tuya_4_button_scene_switch_ts0044.yaml
 mode: single
 max_exceeded: silent
 variables:


### PR DESCRIPTION
The update url of the blueprint does not match the file name. 
There is also a [Tuya TS004F](https://www.zigbee2mqtt.io/devices/TS004F.html) switch. Did you mean to write the blueprint for that device instead? Although I think they may well be identical.